### PR TITLE
Look for Object#initialize_dup in private methods. cr: mike

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -84,7 +84,7 @@ module ActiveModel
     end
 
     # Backport dup from 1.9 so that #initialize_dup gets called
-    unless Object.respond_to?(:initialize_dup)
+    unless Object.respond_to?(:initialize_dup, true)
       def dup # :nodoc:
         copy = super
         copy.initialize_dup(self)

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -1855,7 +1855,7 @@ MSG
       end
 
       # Backport dup from 1.9 so that initialize_dup() gets called
-      unless Object.respond_to?(:initialize_dup)
+      unless Object.respond_to?(:initialize_dup, true)
         def dup # :nodoc:
           copy = super
           copy.initialize_dup(self)


### PR DESCRIPTION
* This imports the fix for Ruby >= 2.0 error "NoMethodError: private
  method `initialize_dup' called" from Rails 3.2.
* Reference: https://github.com/rails/rails/commit/127411f

---

## CR Notes

This change allows us to stay on our version of Rails 3.1.12 and bump Ruby version to 2.0.0. Ultimately we still need Ruby 2.1.10, and we might need to ditch TrackSimple Rails 3.1.12 for standard Rails 3.2.22.2. So I don't know if this intermediate step helps us, but it definitely won't hurt, and I need to reduce the number of unreviewed/uncommitted "balls in the air" right now.

### Testing

Pointed Tequila this branch/version, `bundle install` and full test suite:

http://den00sqb.us.oracle.com/rb/r/159/